### PR TITLE
Add dependencies `certifi` and `wincertstore`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,19 @@ source:
     - setup.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - easy_install = setuptools.command.easy_install:main
 
 requirements:
   build:
     - python
+    - certifi
+    - wincertstore  # [win]
   run:
     - python
+    - certifi
+    - wincertstore  # [win]
 
 test:
   commands:


### PR DESCRIPTION
This adds `certifi` and `wincertstore` as dependencies as `setuptools` intends. While we have to stop `setuptools` from downloading these via [`extras_require`]( https://github.com/conda-forge/setuptools-feedstock/blob/00e1314b0a34895fe4b050f6d049edc811e6f567/recipe/setup.patch ), we should still be able to provide them. Especially as we do have them. This PR does that.

We may want to soften the `setuptools` requirement in `certifi` via PR ( https://github.com/conda-forge/certifi-feedstock/pull/7 ) before we go ahead with this. Hence I have marked this as WIP. `wincertstore` already has a soft dependency on `setuptools` and is installed via `distutils` ATM.