### PR TITLE
Bump to 25.2.0 and include new license file

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,5 +2,8 @@ set SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0
 set SETUPTOOLS_DISABLE_VERSIONED_EASY_INSTALL_SCRIPT=0
 set DISTRIBUTE_DISABLE_VERSIONED_EASY_INSTALL_SCRIPT=0
 
+%PYTHON% bootstrap.py
+if errorlevel 1 exit 1
+
 %PYTHON% setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,4 +3,5 @@
 export SETUPTOOLS_DISABLE_VERSIONED_EASY_INSTALL_SCRIPT=0
 export DISTRIBUTE_DISABLE_VERSIONED_EASY_INSTALL_SCRIPT=0
 
+$PYTHON bootstrap.py
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "25.1.6" %}
+{% set version = "25.2.0" %}
 
 package:
   name: setuptools
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: setuptools-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/s/setuptools/setuptools-{{ version }}.tar.gz
-  sha256: 281e7d21a3e23d0b7d19992ed52fda5b16a9837654de824ce22ae6b80f0e8f96
+  url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
+  sha256: d61a878e7eb7bb8594e66e41bbb5fea42c55fc3b4936425c6c3a512f85f7bce2
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch
@@ -38,6 +38,7 @@ test:
 about:
   home: https://pypi.python.org/pypi/setuptools
   license: MIT
+  license_file: LICENSE
   license_family: MIT
   summary: Download, build, install, upgrade, and uninstall Python packages
   description: |


### PR DESCRIPTION
This bumps the version to 25.2.0 and includes the new license file. In order to do the latter, we switched to GitHub for the source.

**Changelog:**

```
v25.2.0
-------

* #612 via #730: Add a LICENSE file which needs to be provided by the terms of
  the MIT license.
```