### PR TITLE
Bump to 25.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "25.3.0" %}
+{% set version = "25.4.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 5f9b81a5f99c231396556b46e84063cd0cf50284c7e41c53a4f6f2afbe1526cb
+  sha256: 2c0f8f712b82a6e6e4355662550b46c3abf2242c1439ecc3d180ffef2ae9a3f9
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
Changes:

```
v25.4.0
-------

* Add Extension(py_limited_api=True). When set to a truthy value,
  that extension gets a filename apropriate for code using Py_LIMITED_API.
  When used correctly this allows a single compiled extension to work on
  all future versions of CPython 3.
  The py_limited_api argument only controls the filename. To be
  compatible with multiple versions of Python 3, the C extension
  will also need to set -DPy_LIMITED_API=... and be modified to use
  only the functions in the limited API.
```