### PR TITLE
Bump to 26.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "25.4.0" %}
+{% set version = "26.0.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 2c0f8f712b82a6e6e4355662550b46c3abf2242c1439ecc3d180ffef2ae9a3f9
+  sha256: a273bc1af514059a208cdb6570758f21c87f13beb210dceccf4baa7fb122c3e0
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
Changes:

```
v26.0.0
-------

* #748: By default, sdists are now produced in gzipped tarfile
  format by default on all platforms, adding forward compatibility
  for the same behavior in Python 3.6 (See Python #27819).

* #459 via #736: On Windows with script launchers,
  sys.argv[0] now reflects
  the name of the entry point, consistent with the behavior in
  distlib and pip wrappers.

* #752 via #753: When indicating ``py_limited_api`` to Extension,
  it must be passed as a keyword argument.
```