### PR TITLE
Bump to 26.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "26.0.0" %}
+{% set version = "26.1.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: a273bc1af514059a208cdb6570758f21c87f13beb210dceccf4baa7fb122c3e0
+  sha256: 863876db04678c434088564c587490618d8a6129070665a3216707c10792b696
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
Changes:

```
v26.1.0
-------

* #763: ``pkg_resources.get_default_cache`` now defers to the
  `appdirs project <https://pypi.org/project/appdirs>`_ to
  resolve the cache directory. Adds a vendored dependency on
  appdirs to pkg_resources.
```