### PR TITLE
Bump to 26.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 env:
   matrix:
@@ -35,7 +37,5 @@ install:
 
 script:
   - conda build ./recipe
-
-after_success:
 
   - ./ci_support/upload_or_check_non_existence.py ./recipe conda-forge --channel=main

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About setuptools
 ================
 
-Home: https://pypi.python.org/pypi/setuptools
+Home: https://github.com/pypa/setuptools
 
 Package license: MIT
 
@@ -9,6 +9,8 @@ Feedstock license: BSD 3-Clause
 
 Summary: Download, build, install, upgrade, and uninstall Python packages
 
+Setuptools is a fully-featured, actively-maintained, and stable library
+designed to facilitate packaging Python projects.
 
 
 Installing setuptools
@@ -70,7 +72,7 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/setuptools-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/setuptools-feedstock)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/setuptools-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/setuptools-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/setuptools-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/setuptools-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/setuptools-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/setuptools-feedstock/branch/master)
 
@@ -83,12 +85,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/setuptools
 Updating setuptools-feedstock
 =============================
 
-If you would like to improve the setuptools recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the setuptools recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/setuptools-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "26.1.0" %}
+{% set version = "26.1.1" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 863876db04678c434088564c587490618d8a6129070665a3216707c10792b696
+  sha256: 046184de4a40df5679a7ae1be2f7e9bb6866b380368035aff4e99e2d96876db6
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - pkg_resources
 
 about:
-  home: https://pypi.python.org/pypi/setuptools
+  home: https://github.com/pypa/setuptools
   license: MIT
   license_file: LICENSE
   license_family: MIT


### PR DESCRIPTION
Also updated `home` as that changed was changed some time ago (March 2016) in PR ( https://github.com/pypa/setuptools/pull/560 ).

Changes:

```
v26.1.1

* Re-release of 26.1.0 with pytest pinned to allow for automated deployement and thus proper packaging environment variables, fixing issues with missing executable launchers.
```