### PR TITLE
Release 27.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "26.1.1" %}
+{% set version = "27.0.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 046184de4a40df5679a7ae1be2f7e9bb6866b380368035aff4e99e2d96876db6
+  sha256: 8613a112e5978e259e6522ad8b0caf6a42d019fa1fa0815e32933ae39aaf85ff
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
``` rst
v27.0.0
-------

* Now use Warehouse by default for
  ``upload``, patching ``distutils.config.PyPIRCCommand`` to
  affect default behavior.

  Any config in .pypirc should be updated to replace

    https://pypi.python.org/pypi/

  with

    https://upload.pypi.org/legacy/

  Similarly, any passwords stored in the keyring should be
  updated to use this new value for "system".

  The ``upload_docs`` command will continue to use the python.org
  site, but the command is now deprecated. Users are urged to use
  Read The Docs instead.

* #776: Use EXT_SUFFIX for py_limited_api renaming.

* #774 and #775: Use LegacyVersion from packaging when
  detecting numpy versions.
```
