### PR TITLE
Release 27.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "27.1.0" %}
+{% set version = "27.1.1" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 2a9f38eeaf8c4dfa6a633a6713c8e817a644f3d9a1a1e2c9dfac3697b2821e00
+  sha256: b7670ab159c29abd60627299cfb55993e0611451df98417311b351f0a89c5db4
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "27.1.1" %}
+{% set version = "27.1.2" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: b7670ab159c29abd60627299cfb55993e0611451df98417311b351f0a89c5db4
+  sha256: aa7228786d5740138507cf3b794915fa01855d8fae51f2febc4bce3536320c70
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
Replaces https://github.com/conda-forge/setuptools-feedstock/pull/23 ( `27.1.1` )

```rst
v27.1.2
-------

* #779 via #781: Fix circular import.

v27.1.1
-------

* #778: Fix MSVC monkeypatching.
```