### PR TITLE
Release 27.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "27.2.0" %}
+{% set version = "27.3.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 2aa6a37bcd49607dfd7de17de79568c7709c5424851f262d9c969f5e58e43666
+  sha256: c661d4061e2a6f71519237ba423ed461d210b8ca541e1bdd83048d38f97e5641
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```rst
v27.3.0
-------

* #794: In test command, add installed eggs to PYTHONPATH
  when invoking tests so that subprocesses will also have the
  dependencies available. Fixes `tox 330
  <https://github.com/tox-dev/tox/issues/330>`_.

* #795: Update vendored pyparsing 2.1.9.
```