### PR TITLE
Release 27.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "27.3.0" %}
+{% set version = "27.3.1" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: c661d4061e2a6f71519237ba423ed461d210b8ca541e1bdd83048d38f97e5641
+  sha256: 2199a93252f2cb163ab5715d09b772a961f67d2500ff8e173f543144160b955a
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```rst
v27.3.1
-------

* #790: In MSVC monkeypatching, explicitly patch each
  function by name in the target module instead of inferring
  the module from the function's ``__module__``. Improves
  compatibility with other packages that might have previously
  patched distutils functions (i.e. NumPy).
```