### PR TITLE
Release 28.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "28.0.0" %}
+{% set version = "28.3.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 769564849ecd0b0f307060981b2d5d13ad29412b3f0cbd91682417352dfb0de7
+  sha256: 726d5247151b1be1fcc6b64bdb22df029364a75a4856a464ad88be65d285ab46
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```rst
v28.3.0
-------

* #809: In ``find_packages()``, restore support for excluding
  a parent package without excluding a child package.

* #805: Disable ``-nspkg.pth`` behavior on Python 3.3+ where
  PEP-420 functionality is adequate. Fixes pip #1924.
```

---

**Note:** 28.2.0 and 28.3.0 are identical. So we skipped the former. Plus
there is no changelog entry for the former so we used the latter. There
may have been issues uploading to PyPI or similar.

**Additional note:** 28.1.0 amounted to an adjustment of the certifi link.
As such, it seems totally unnecessary to build a conda package for it as
one could use 28.0.0 just the same.