### PR TITLE
Release 28.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "28.3.0" %}
+{% set version = "28.4.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 726d5247151b1be1fcc6b64bdb22df029364a75a4856a464ad88be65d285ab46
+  sha256: d6cfc18e8b6dfe71ae7344bc887963d520583d7f363166a422b13ac75e51cdf3
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```rsr
v28.4.0
-------

* #732: Now extras with a hyphen are honored per PEP 426.
* #811: Update to pyparsing 2.1.10.
* Updated ``setuptools.command.sdist`` to re-use most of
  the functionality directly from ``distutils.command.sdist``
  for the ``add_defaults`` method with strategic overrides.
  See #750 for rationale.
* #760 via #762: Look for certificate bundle where SUSE
  Linux typically presents it. Use ``certifi.where()`` to locate
  the bundle.
```