### PR TITLE
Release 28.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "28.4.0" %}
+{% set version = "28.5.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: d6cfc18e8b6dfe71ae7344bc887963d520583d7f363166a422b13ac75e51cdf3
+  sha256: fdc7b1f07ca5a8d216b80eb5e349aff3465cd91356bd27b236a1af2e77096453
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```rst
v28.5.0
-------

* #810: Tests are now invoked with tox and not setup.py test.
* #249 and #450 via #764: Avoid scanning the whole tree
  when building the manifest.
```