### PR TITLE
Release 28.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "28.5.0" %}
+{% set version = "28.6.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: fdc7b1f07ca5a8d216b80eb5e349aff3465cd91356bd27b236a1af2e77096453
+  sha256: 72e0b0dc09e7968446920be7fb9609116c89d386d5d12640f36460c7d1f7cf17
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```rst
v28.6.0
-------

* #629: When scanning for packages, ``pkg_resources`` now
  ignores empty egg-info directories and gives precedence to
  packages whose versions are lexicographically greatest,
  a rough approximation for preferring the latest available
  version.
```