### PR TITLE
Release 28.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "28.6.1" %}
+{% set version = "28.7.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 197b0c1e69a29c3a9eab446ef0a1884890da0c9784b8f556d0c64071819991d6
+  sha256: 3e33f55d8fb40693528aae33823d8488cca9606e3c4107b1b1aae881c869d4fc
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```rst
v28.7.0
-------

* #832: Moved much of the namespace package handling
  functionality into a separate module for re-use in something
  like #789.
* #830: ``sdist`` command no longer suppresses the inclusion
  of data files, re-aligning with the expectation of distutils
  and addressing #274 and #521.
```