### PR TITLE
Release 29.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "28.8.0" %}
+{% set version = "29.0.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: d3b2c63a5cb6816ace0883bc3f6aca9e7890c61d80ac0d608a183f85825a7cc0
+  sha256: 17667ea03d21180e1d2ba6c2c7a11eacafb3cdb7da4853f1edbf85e30b87ce64
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch
@@ -52,3 +52,4 @@ extra:
     - jakirkham
     - msarahan
     - ocefpaf
+    - nicoddemus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "29.0.0" %}
+{% set version = "29.0.1" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 17667ea03d21180e1d2ba6c2c7a11eacafb3cdb7da4853f1edbf85e30b87ce64
+  sha256: 95fc53e1c2732593a05c12ad38ed160a228f7d1a19dab2eb778a8a47d73354e0
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
v29.0.1
-------

* #861: Re-release of v29.0.1 with the executable script
  launchers bundled. Now, launchers are included by default
  and users that want to disable this behavior must set the
  environment variable
  'SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES' to
  a false value like "false" or "0".