### PR TITLE
Update to 31.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "31.0.0" %}
+{% set version = "31.0.1" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 41667ed238d884c3f18012f864c1a44b6cc456f5302b283e7f0c916e8649e8e9
+  sha256: 0d16f249c808490e1e7df6bd87e7bf92179d4d4f64a9244f5be21dd5dc9e645f
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "29.0.1" %}
+{% set version = "31.0.0" %}
 
 package:
   name: setuptools
@@ -7,13 +7,13 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: 95fc53e1c2732593a05c12ad38ed160a228f7d1a19dab2eb778a8a47d73354e0
+  sha256: 41667ed238d884c3f18012f864c1a44b6cc456f5302b283e7f0c916e8649e8e9
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - easy_install = setuptools.command.easy_install:main
 


### PR DESCRIPTION
```
v31.0.0
-------

* #250: Install '-nspkg.pth' files for packages installed
  with 'setup.py develop'. These .pth files allow
  namespace packages installed by pip or develop to
  co-mingle. This change required the removal of the
  change for #805 and pip #1924, introduced in 28.3.0 and implicated
  in #870, but means that namespace packages not in a
  site packages directory will no longer work on Python
  earlier than 3.5, whereas before they would work on
  Python not earlier than 3.3.
```