### PR TITLE
NO MRG, MNT: Re-render AppVeyor Tidy-up test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,16 +58,10 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
+    # Add a hack to update conda as the included copy is too old.
     - cmd: set "OLDPATH=%PATH%"
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: conda update --yes --quiet conda
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
@@ -75,6 +69,11 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup


### PR DESCRIPTION
Please do **not** merge this. It is for testing purposes only.

Tests out a re-rendering using a development version of conda-smithy. Hopefully should allow us to clean out some old hacks from the AppVeyor CI configuration.

xref: https://github.com/conda-forge/conda-smithy/pull/402