### PR TITLE
Update to 34.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "33.1.0" %}
+{% set version = "34.1.0" %}
 
 package:
   name: setuptools
@@ -7,7 +7,7 @@ package:
 source:
   fn: setuptools-{{ version }}.tar.gz
   url: https://github.com/pypa/setuptools/archive/v{{ version }}.tar.gz
-  sha256: efa8538fec784c6d33af572abbc6662ae5f3e3bd6d7bbc42124080492215cb45
+  sha256: 96786df8bedf2152b02a4170931ae1acb73685cc854d57bbd23fa8080cf09b95
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - nodownload.patch


### PR DESCRIPTION
```
v34.1.0
-------

* #930: ``build_info`` now accepts two new parameters
  to optimize and customize the building of C libraries.

v34.0.3
-------

* #947: Loosen restriction on the version of six required,
  restoring compatibility with environments relying on
  six 1.6.0 and later.

v34.0.2
-------

* #882: Ensure extras are honored when building the
  working set.
* #913: Fix issue in develop if package directory has
  a trailing slash.

v34.0.1
-------

* #935: Fix glob syntax in graft.

v34.0.0
-------

* #581: Instead of vendoring the growing list of
  dependencies that Setuptools requires to function,
  Setuptools now requires these dependencies just like
  any other project. Unlike other projects, however,
  Setuptools cannot rely on ``setup_requires`` to
  demand the dependencies it needs to install because
  its own machinery would be necessary to pull those
  dependencies if not present (a bootstrapping problem).
  As a result, Setuptools no longer supports self upgrade or
  installation in the general case. Instead, users are
  directed to use pip to install and upgrade using the
  ``wheel`` distributions of setuptools.

  Users are welcome to contrive other means to install
  or upgrade Setuptools using other means, such as
  pre-installing the Setuptools dependencies with pip
  or a bespoke bootstrap tool, but such usage is not
  recommended and is not supported.

  As discovered in #940, not all versions of pip will
  successfully install Setuptools from its pre-built
  wheel. If you encounter issues with "No module named
  six" or "No module named packaging", especially
  following a line "Running setup.py egg_info for package
  setuptools", then your pip is not new enough.

  There's an additional issue in pip where setuptools
  is upgraded concurrently with other source packages,
  described in pip #4253. The proposed workaround is to
  always upgrade Setuptools first prior to upgrading
  other packages that would upgrade Setuptools.

v33.1.1
-------

* #921: Correct issue where certifi fallback not being
  reached on Windows.
```