### PR TITLE
Add a 59.x LTS branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @isuruf @jakirkham @msarahan @nicoddemus @ocefpaf
+* @isuruf @jakirkham @msarahan @nicoddemus @ocefpaf @rgommers

--- a/README.md
+++ b/README.md
@@ -344,4 +344,5 @@ Feedstock Maintainers
 * [@msarahan](https://github.com/msarahan/)
 * [@nicoddemus](https://github.com/nicoddemus/)
 * [@ocefpaf](https://github.com/ocefpaf/)
+* [@rgommers](https://github.com/rgommers/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,4 @@
+bot: {abi_migration_branches: 59_x}
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "60.5.0" %}
+{% set version = "59.8.0" %}
 
 package:
   name: setuptools
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/setuptools/setuptools-{{ version }}.tar.gz
-  sha256: 2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe
+  sha256: 09980778aa734c3037a47997f28d6db5ab18bdf2af0e49f719bfc53967fd2e82
   patches:
     # distutils patches from python-feedstock
     - patches/0012-Disable-new-dtags-in-unixccompiler.py.patch  # [py<=39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,3 +51,4 @@ extra:
     - ocefpaf
     - nicoddemus
     - isuruf
+    - rgommers


### PR DESCRIPTION
This is needed because multiple projects need to pin to `setuptools < 60.0`, which was the release that enabled the
vendored copy of `distutils` inside `setuptools`. That `distutils` copy contains backwards incompatible changes which
NumPy and SciPy don't support; other projects like Pandas and Dask use that pin too because of the `LooseVersion` deprecation in 60.0

See https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/204 for more details.

`[ci skip]`

Also add myself as recipe maintainer.

**Note:** @beckermr suggested a procedure at https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/204#issuecomment-1013718192 that involves adding a branch to this repo (it should be named `59_x` like in this PR). I don't have permissions to push that branch, so it'd be great if a reviewer could do this.
