### PR TITLE
Fix backports.tarfile vendored requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:
@@ -20,6 +20,10 @@ requirements:
     - python >=3.8
   run:
     - python >=3.8
+    # jaraco.context needs backports.tarfile, but on Python 3.8 the
+    # _explicit_ namespace package 'backports' breaks the vendored
+    # package discovery for backports.tarfile
+    - backports.tarfile  # [py<39]
 
 test:
   imports:


### PR DESCRIPTION
This PR fixes #351 by adding an explicit requirement on a vendored package that cannot be imported from the `setuptools._vendor` namespace on Python 3.8.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
